### PR TITLE
Fetch song information and return metadata for song page embeds

### DIFF
--- a/web/public/docs/guidelines.md
+++ b/web/public/docs/guidelines.md
@@ -2,7 +2,7 @@
 
 > Last updated: October 7, 2024
 
-Welcome to **Note Block World**! We strive to be the best online community for everyone to create, share, and listen to note block music from around the world, no matter your level of experience!
+Welcome to **Note Block World**! We strive to be the best online community for everyone to discover, share, and listen to note block music from around the world, no matter your level of experience!
 
 In this page, you’ll find a few guidelines that we’ve put in place to help keep Note Block World a healthy, safe, and positive space for all of our members. We kindly ask that you read these Guidelines carefully and follow them closely when contributing to the community!
 

--- a/web/src/app/(content)/(info)/about/page.tsx
+++ b/web/src/app/(content)/(info)/about/page.tsx
@@ -6,15 +6,7 @@ import { NoteBlockWorldLogo } from '@web/src/modules/shared/components/NoteBlock
 import About from './about.mdx';
 
 export const metadata: Metadata = {
-  title: {
-    template: '%s | Help',
-    default: 'Note Block World',
-  },
-  openGraph: {
-    title: 'Create, share and listen to note block music',
-    description: 'Note Block World',
-    siteName: 'Note Block World',
-  },
+  title: 'About',
 };
 
 const AboutPage = () => {

--- a/web/src/app/(content)/(info)/blog/page.tsx
+++ b/web/src/app/(content)/(info)/blog/page.tsx
@@ -5,7 +5,11 @@ import Link from 'next/link';
 
 import { getSortedPostsData } from '@web/src/lib/posts';
 import type { PostType } from '@web/src/lib/posts';
+import { Metadata } from 'next';
 
+export const metadata: Metadata = {
+  title: 'Blog',
+};
 async function BlogPage() {
   const allPostsData = getSortedPostsData('blog', 'date');
   return <BlogPageComponent posts={allPostsData}></BlogPageComponent>;

--- a/web/src/app/(content)/(info)/contact/page.tsx
+++ b/web/src/app/(content)/(info)/contact/page.tsx
@@ -5,15 +5,7 @@ import BackButton from '@web/src/modules/shared/components/client/BackButton';
 import Contact from './contact.mdx';
 
 export const metadata: Metadata = {
-  title: {
-    template: '%s | Help',
-    default: 'Note Block World',
-  },
-  openGraph: {
-    title: 'Create, share and listen to note block music',
-    description: 'Note Block World',
-    siteName: 'Note Block World',
-  },
+  title: 'Contact',
 };
 
 const AboutPage = () => {

--- a/web/src/app/(content)/(info)/help/[id]/page.tsx
+++ b/web/src/app/(content)/(info)/help/[id]/page.tsx
@@ -18,15 +18,11 @@ export function generateMetadata({ params }: HelpPageProps): Metadata {
   const publicUrl = process.env.NEXT_PUBLIC_URL;
 
   return {
-    title: {
-      template: '%s | Help',
-      default: 'Note Block World',
-    },
+    title: post.title,
     authors: [{ name: post.author }],
     openGraph: {
       url: publicUrl + '/help/' + id,
       title: post.title,
-      description: 'Create, share and listen to note block music',
       siteName: 'Note Block World',
       images: [
         {

--- a/web/src/app/(content)/(info)/help/page.tsx
+++ b/web/src/app/(content)/(info)/help/page.tsx
@@ -5,6 +5,11 @@ import Link from 'next/link';
 
 import { getSortedPostsData } from '@web/src/lib/posts';
 import type { PostType } from '@web/src/lib/posts';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Help Center',
+};
 
 async function HelpPage() {
   const allPostsData = getSortedPostsData('help', 'id');

--- a/web/src/app/(content)/my-songs/page.tsx
+++ b/web/src/app/(content)/my-songs/page.tsx
@@ -2,6 +2,11 @@ import { redirect } from 'next/navigation';
 
 import { checkLogin } from '@web/src/modules/auth/features/auth.utils';
 import Page from '@web/src/modules/my-songs/components/MySongsPage';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'My songs',
+};
 
 const MySongsPage = async () => {
   // TODO: Next.js extends fetch() to memoize the result of multiple requests to the same URL.

--- a/web/src/app/(content)/page.tsx
+++ b/web/src/app/(content)/page.tsx
@@ -2,6 +2,7 @@ import {
   FeaturedSongsDtoType,
   SongPreviewDtoType,
 } from '@shared/validation/song/dto/types';
+import { Metadata } from 'next';
 
 import axiosInstance from '@web/src/lib/axios';
 import { HomePageProvider } from '@web/src/modules/browse/components/client/context/HomePage.context';
@@ -45,6 +46,10 @@ async function fetchFeaturedSongs(): Promise<FeaturedSongsDtoType> {
     };
   }
 }
+
+export const metadata: Metadata = {
+  title: 'Songs',
+};
 
 async function Home() {
   const recentSongs = await fetchRecentSongs();

--- a/web/src/app/(content)/song/[id]/page.tsx
+++ b/web/src/app/(content)/song/[id]/page.tsx
@@ -14,6 +14,7 @@ export async function generateMetadata({
   params,
 }: SongPage): Promise<Metadata> {
   let song;
+  const publicUrl = process.env.NEXT_PUBLIC_URL;
 
   try {
     const response = await axios.get<SongViewDtoType>(`/song/${params.id}`);
@@ -27,7 +28,12 @@ export async function generateMetadata({
   return {
     title: song.title,
     description: song.description,
+    authors: [{ name: song.uploader.username }],
     openGraph: {
+      url: publicUrl + '/song/' + song.publicId,
+      title: song.title,
+      description: song.description,
+      siteName: 'Note Block World',
       images: [song.thumbnailUrl],
     },
     twitter: {

--- a/web/src/app/(content)/song/[id]/page.tsx
+++ b/web/src/app/(content)/song/[id]/page.tsx
@@ -1,6 +1,39 @@
+import { SongViewDtoType } from '@shared/validation/song/dto/types';
+import type { Metadata } from 'next';
+
+import axios from '@web/src/lib/axios';
 import { SongPage } from '@web/src/modules/song/components/SongPage';
 
-function Page({ params }: { params: { id: string } }) {
+interface SongPage {
+  params: {
+    id: string;
+  };
+}
+
+export async function generateMetadata({
+  params,
+}: SongPage): Promise<Metadata> {
+  let song;
+
+  try {
+    const response = await axios.get<SongViewDtoType>(`/song/${params.id}`);
+    song = response.data;
+  } catch {
+    return {
+      title: 'Unknown song!',
+    };
+  }
+
+  return {
+    title: song.title,
+    description: song.description,
+    openGraph: {
+      images: [song.thumbnailUrl],
+    },
+  };
+}
+
+function Page({ params }: SongPage) {
   const { id } = params;
 
   return <SongPage id={id} />;

--- a/web/src/app/(content)/song/[id]/page.tsx
+++ b/web/src/app/(content)/song/[id]/page.tsx
@@ -30,6 +30,9 @@ export async function generateMetadata({
     openGraph: {
       images: [song.thumbnailUrl],
     },
+    twitter: {
+      card: 'summary_large_image',
+    },
   };
 }
 

--- a/web/src/app/(content)/upload/page.tsx
+++ b/web/src/app/(content)/upload/page.tsx
@@ -5,6 +5,11 @@ import {
   getUserData,
 } from '@web/src/modules/auth/features/auth.utils';
 import { UploadSongPage } from '@web/src/modules/song-upload/components/client/UploadSongPage';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Upload song',
+};
 
 async function UploadPage() {
   const isLogged = await checkLogin();

--- a/web/src/app/(external)/(auth)/login/page.tsx
+++ b/web/src/app/(external)/(auth)/login/page.tsx
@@ -2,6 +2,11 @@ import { redirect } from 'next/navigation';
 
 import { LoginPage } from '@web/src/modules/auth/components/loginPage';
 import { checkLogin } from '@web/src/modules/auth/features/auth.utils';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign in',
+};
 
 const Login = async () => {
   const isLogged = await checkLogin();

--- a/web/src/app/(external)/(legal)/privacy/page.tsx
+++ b/web/src/app/(external)/(legal)/privacy/page.tsx
@@ -2,7 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { CustomMarkdown } from '@web/src/modules/shared/components/CustomMarkdown';
+import { Metadata } from 'next';
 
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+};
 async function PrivacyPolicyPage() {
   const fullPath = path.join('./public/docs/privacy.md');
   const fileContents = fs.readFileSync(fullPath, 'utf8');

--- a/web/src/app/(external)/(legal)/terms/page.tsx
+++ b/web/src/app/(external)/(legal)/terms/page.tsx
@@ -2,7 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { CustomMarkdown } from '@web/src/modules/shared/components/CustomMarkdown';
+import { Metadata } from 'next';
 
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+};
 async function TermsOfServicePage() {
   const fullPath = path.join('./public/docs/terms.md');
   const fileContents = fs.readFileSync(fullPath, 'utf8');

--- a/web/src/app/(external)/[...not-found]/page.tsx
+++ b/web/src/app/(external)/[...not-found]/page.tsx
@@ -1,8 +1,12 @@
+import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 // TODO: this is only necessary because of a bug in Next.js regarding route layouts and custom not found pages.
 // See: https://github.com/vercel/next.js/discussions/50034
 
+export const metadata: Metadata = {
+  title: 'Page not found',
+};
 export default function NotFound() {
   notFound();
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -18,9 +18,15 @@ const lato = Lato({
   weight: ['100', '300', '400', '700', '900'],
 });
 
-const metadata: Metadata = {
-  title: 'Note Block World',
+export const metadata: Metadata = {
+  title: { template: '%s | Note Block World', default: '' },
   description: 'Create, share and listen to note block music',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: process.env.NEXT_PUBLIC_URL,
+    siteName: 'Note Block World',
+  },
 };
 
 export default function RootLayout({

--- a/web/src/modules/browse/WelcomeBanner.tsx
+++ b/web/src/modules/browse/WelcomeBanner.tsx
@@ -20,7 +20,7 @@ export const WelcomeBanner = () => {
         </h1>
         <p className='mb-1 text-green-100'>
           We&apos;re the largest public community centered around Minecraft note
-          blocks, where you can create, share and listen to note block music
+          blocks, where you can discover, share and listen to note block music
           from all around the world.
         </p>
         <p className='mb-2'>


### PR DESCRIPTION
This current implementation is not ideal. When this page is loaded, it will create two identical requests to the backend to fetch data server-side, as well as client-side. I'm unsure of any better ways to do this with Next.js, so it may just have to do.

This is a very bare-bones implementation, but it should do the job for now.

Partially implements [OG tags & image generation](https://github.com/orgs/OpenNBS/projects/4/views/2?sliceBy%5Bvalue%5D=Second+release&pane=issue&itemId=52078709), using the existing thumbnail as the image.