### PR TITLE
Add dynamic `robots.txt` generation

### DIFF
--- a/apps/frontend/src/app/robots.ts
+++ b/apps/frontend/src/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  // Check if the current deployment is Production
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (isProd) {
+    return {
+      rules: {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/'], // Block search engines from sensitive paths
+      },
+      sitemap: 'https://noteblock.world',
+    };
+  }
+
+  // Block ALL crawling on Preview, Staging, and Local environments
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: '/',
+    },
+  };
+}


### PR DESCRIPTION
## Overview

Since `up.railway.app` has been added to the list of [public suffixes](https://github.com/publicsuffix/list/blob/9186eeeda85cef35b1551d00731464939c765cab/public_suffix_list.dat#L15330), we are no longer able to set cookies in development/staging deployments using Railway-provided subdomains.

To improve the development experience, we're deploying staging environments into our own `noteblock.world` subdomains. To prevent web crawlers from indexing staging content, we're adding a dynamically generated [robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots) file based on the `NODE_ENV` variable, thereby preventing web crawling in non-production deployments.