### PR TITLE
Introduce `APP_ENV` variable to frontend

### DIFF
--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -1,5 +1,6 @@
 THUMBNAIL_URL=localhost
 #THUMBNAIL_URL=localhost:9000
+APP_ENV=local
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=
 NEXT_PUBLIC_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:4000/v1

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -2,7 +2,12 @@ import createMDX from '@next/mdx';
 
 /** @type {import('next').NextConfig} */
 
+const appEnv = process.env.APP_ENV ?? 'local';
+
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_ENV: appEnv,
+  },
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
   // Externalize packages that use Node.js built-in modules for server components
   serverExternalPackages: ['@nbw/database', '@nbw/config'],

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { WebSite, WithContext } from 'schema-dts';
 
 import DetectAdBlock from '../modules/shared/components/client/ads/DetectAdBlock';
 import GoogleAdSense from '../modules/shared/components/GoogleAdSense';
+import { isProductionAppEnv } from '@web/lib/appEnv';
 import { TooltipProvider } from '../modules/shared/components/tooltip';
 
 // Pre-import FontAwesome CSS to avoid FOUC
@@ -126,10 +127,9 @@ export default function RootLayout({
           </SkeletonTheme>
           <DetectAdBlock />
         </body>
-        {process.env.NODE_ENV === 'production' &&
-          process.env.NEXT_PUBLIC_GA_ID && (
-            <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
-          )}
+        {isProductionAppEnv() && process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
       </html>
     </ReCaptchaProvider>
   );

--- a/apps/frontend/src/app/robots.ts
+++ b/apps/frontend/src/app/robots.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from 'next';
 
+import { isProductionAppEnv } from '@web/lib/appEnv';
+
 export default function robots(): MetadataRoute.Robots {
-  // Check if the current deployment is Production
-  const isProd = process.env.NODE_ENV === 'production';
+  const isProd = isProductionAppEnv();
 
   if (isProd) {
     return {

--- a/apps/frontend/src/lib/appEnv.ts
+++ b/apps/frontend/src/lib/appEnv.ts
@@ -1,0 +1,29 @@
+export const APP_ENVS = [
+  'local',
+  'development',
+  'staging',
+  'production',
+] as const;
+
+export type AppEnv = (typeof APP_ENVS)[number];
+
+function parseAppEnv(value: string | undefined): AppEnv {
+  if (value && APP_ENVS.includes(value as AppEnv)) {
+    return value as AppEnv;
+  }
+
+  return 'local';
+}
+
+/** Deployment environment for app behavior (not Node.js build optimizations). */
+export function getAppEnv(): AppEnv {
+  return parseAppEnv(process.env.APP_ENV ?? process.env.NEXT_PUBLIC_APP_ENV);
+}
+
+export function isProductionAppEnv(): boolean {
+  return getAppEnv() === 'production';
+}
+
+export function isLocalAppEnv(): boolean {
+  return getAppEnv() === 'local';
+}

--- a/apps/frontend/src/modules/auth/components/client/login.util.ts
+++ b/apps/frontend/src/modules/auth/components/client/login.util.ts
@@ -2,6 +2,8 @@
 //import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+import { isLocalAppEnv } from '@web/lib/appEnv';
+
 export function deleteAuthCookies() {
   // delete cookie
   const cookiesToBeDeleted = ['refresh_token', 'token'];
@@ -9,7 +11,7 @@ export function deleteAuthCookies() {
   cookiesToBeDeleted.forEach((cookie) => {
     if (!document) return;
 
-    if (process.env.NODE_ENV === 'development') {
+    if (isLocalAppEnv()) {
       document.cookie = `${cookie}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/`;
     } else {
       document.cookie = `${cookie}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=${process.env.NEXT_PUBLIC_APP_DOMAIN}`;

--- a/apps/frontend/src/modules/shared/components/GoogleAdSense.tsx
+++ b/apps/frontend/src/modules/shared/components/GoogleAdSense.tsx
@@ -1,5 +1,7 @@
+import { isProductionAppEnv } from '@web/lib/appEnv';
+
 const GoogleAdSense = ({ pId }: { pId?: string }) => {
-  if (process.env.NODE_ENV !== 'production' || !pId) {
+  if (!isProductionAppEnv() || !pId) {
     return null;
   }
 

--- a/apps/frontend/src/modules/shared/components/client/ads/useAdSenseClient.tsx
+++ b/apps/frontend/src/modules/shared/components/client/ads/useAdSenseClient.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 
+import { isProductionAppEnv } from '@web/lib/appEnv';
+
 const useAdSenseClient = () => {
   const pubId = useMemo(() => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProductionAppEnv()) {
       return null;
     }
 


### PR DESCRIPTION
# Overview

Some website features, such as crawler indexing (`robots.txt`), ads, and analytics should only ever be enabled in production deployments. So far, we had been using `NODE_ENV` to signal whether or not we were running a production deployment. As mentioned in the Node.js documentation, [this usage is considered an antipattern](https://nodejs.org/learn/getting-started/nodejs-the-difference-between-development-and-production#why-is-node_env-considered-an-antipattern). The only acceptable value for the `NODE_ENV` variable is `production` which by convention indicates we're running with production-mode optimizations (or the absence of it, which signals otherwise) for some libraries.

This means that `NODE_ENV=production` is the appropriate mode for us to run our development/staging environments on, which we already do. However, this means that our previous checks/assumptions for whether we're running in production were wrong, because our development environment also runs with `NODE_ENV=production`. In turn, `robots.txt` was not avoiding crawling, ad code was being loaded etc. in our development environment.

This PR introduces the `APP_ENV` environment variable on the **frontend**, which can assume values `local`, `development`, `staging` and `production`.
`NODE_ENV is always supposed to be `production` in non-development environments.

# Additions

## `APP_ENV` utility

New shared helper at `apps/frontend/src/lib/appEnv.ts`:

- Values: `local`, `development`, `staging`, `production`
- Reads `APP_ENV` (server/build) or `NEXT_PUBLIC_APP_ENV` (client)
- Defaults to `local` if unset or invalid
- Helpers: `getAppEnv()`, `isProductionAppEnv()`, `isLocalAppEnv()`

## `next.config.mjs`

`APP_ENV` is forwarded to the client at build time via `NEXT_PUBLIC_APP_ENV`, so client components can use the same value without duplicating env vars.

## Updated call sites

All behavioral `NODE_ENV` checks in the frontend now use `APP_ENV`:

| File | Change |
|------|--------|
| `robots.ts` | Allows crawling only when `APP_ENV=production` |
| `layout.tsx` | Google Analytics only in production |
| `GoogleAdSense.tsx` | AdSense script only in production |
| `useAdSenseClient.tsx` | AdSense client ID only in production |
| `login.util.ts` | Cookie domain logic uses `isLocalAppEnv()` instead of `NODE_ENV === 'development'` |

## Configuration

Set `APP_ENV` per deployment:

```bash
# Local (.env.local)
APP_ENV=local

# Staging
APP_ENV=staging

# Production
APP_ENV=production
```

On staging, set `APP_ENV=staging` (or `development`) even if `NODE_ENV=production` for the Next.js build. That keeps build optimizations while blocking crawlers, ads, and analytics.

`apps/frontend/.env.local.example` already includes `APP_ENV=local`.

This matches the [Node.js guidance](https://nodejs.org/learn/getting-started/nodejs-the-difference-between-development-and-production#why-is-node_env-considered-an-antipattern): keep `NODE_ENV=production` for builds, and use `APP_ENV` for deployment-specific behavior.